### PR TITLE
Implement additional file uninstallation

### DIFF
--- a/NickelHook.h
+++ b/NickelHook.h
@@ -36,6 +36,7 @@ struct nh_info {
     const char *desc;            // default: none - human-readable description
     const char *uninstall_flag;  // default: none - path to flag which triggers an uninstall and deletes itself if it exists
     const char *uninstall_xflag; // default: none - path to flag which triggers an uninstall if it is deleted
+    const char **uninstall_files;// default: none - null terminated array of file/directory paths to delete during uninstall
     int        failsafe_delay;   // default: 0    - delay in seconds before disarming failsafe
 
     // TODO: maybe a mechanism to only load the latest version?


### PR DESCRIPTION
Basically, this allows the user to specify additional files/directories to uninstall. Useful if the mod installs additional files in its KoboRoot.tgz

I think this should be safe enough now, although I have no issues if you decide you don't want to support this functionality.

With the safeguards in place, it should not delete anything critical to the recovery process if the developer forgets to NULL terminate their array of paths.