### PR TITLE
Enhanced uninstallation and file deletion - take 2

### DIFF
--- a/NickelHook.h
+++ b/NickelHook.h
@@ -26,6 +26,7 @@ struct nh {
     struct nh_info  *info;
     struct nh_hook  *hook;  // pointer to the first element, NULL terminated
     struct nh_dlsym *dlsym; // pointer to the first element, NULL terminated
+    void (*uninstall)(); // optional, allow extra cleanup on uninstall
 };
 
 // nh_info contains information about the mod.
@@ -36,7 +37,6 @@ struct nh_info {
     const char *desc;            // default: none - human-readable description
     const char *uninstall_flag;  // default: none - path to flag which triggers an uninstall and deletes itself if it exists
     const char *uninstall_xflag; // default: none - path to flag which triggers an uninstall if it is deleted
-    const char **uninstall_files;// default: none - null terminated array of file/directory paths to delete during uninstall
     int        failsafe_delay;   // default: 0    - delay in seconds before disarming failsafe
 
     // TODO: maybe a mechanism to only load the latest version?
@@ -63,6 +63,10 @@ struct nh_dlsym {
     const char *desc;    // default: none  - human-readable description
     bool       optional; // default: false - prevents a failure to resolve the sym from being treated as a fatal error, and sets it to NULL instead
 };
+
+// nh_delete_path deletes the provided path if it exists. It performs some checks
+// to detect and avoid deleting critical system files
+__attribute__((visibility("default"))) void nh_delete_path(const char *path);
 
 // nh_log logs a message with a prefix based on the mod name, and should be used
 // for all logging. Messages larger than 256 bytes will be silently  truncated.

--- a/NickelHook.h
+++ b/NickelHook.h
@@ -26,7 +26,8 @@ struct nh {
     struct nh_info  *info;
     struct nh_hook  *hook;  // pointer to the first element, NULL terminated
     struct nh_dlsym *dlsym; // pointer to the first element, NULL terminated
-    void (*uninstall)(); // optional, allow extra cleanup on uninstall
+
+    bool (*uninstall)(); // optional, allow extra cleanup on uninstall
 };
 
 // nh_info contains information about the mod.

--- a/NickelHook.h
+++ b/NickelHook.h
@@ -66,9 +66,10 @@ struct nh_dlsym {
 };
 
 // nh_delete_* deletes the provided path if it exists. It performs some checks
-// to detect and avoid deleting critical system files
-__attribute__((visibility("default"))) void nh_delete_file(const char *path);
-__attribute__((visibility("default"))) void nh_delete_dir(const char *path);
+// to detect and avoid deleting critical system files. The functions return true
+// if the path was removed, or false otherwise.
+__attribute__((visibility("default"))) bool nh_delete_file(const char *path);
+__attribute__((visibility("default"))) bool nh_delete_dir(const char *path);
 
 // nh_log logs a message with a prefix based on the mod name, and should be used
 // for all logging. Messages larger than 256 bytes will be silently  truncated.

--- a/NickelHook.h
+++ b/NickelHook.h
@@ -68,6 +68,9 @@ struct nh_dlsym {
 // nh_delete_* deletes the provided path if it exists. It performs some checks
 // to detect and avoid deleting critical system files. The functions return true
 // if the path was removed, or false otherwise.
+// Note, nh_delete_dir will only delete empty directories. Use nh_delete_file and/or
+// nh_delete_dir to delete any files or directories within before attempting to delete
+// a directory.
 __attribute__((visibility("default"))) bool nh_delete_file(const char *path);
 __attribute__((visibility("default"))) bool nh_delete_dir(const char *path);
 

--- a/NickelHook.h
+++ b/NickelHook.h
@@ -64,9 +64,10 @@ struct nh_dlsym {
     bool       optional; // default: false - prevents a failure to resolve the sym from being treated as a fatal error, and sets it to NULL instead
 };
 
-// nh_delete_path deletes the provided path if it exists. It performs some checks
+// nh_delete_* deletes the provided path if it exists. It performs some checks
 // to detect and avoid deleting critical system files
-__attribute__((visibility("default"))) void nh_delete_path(const char *path, bool is_dir);
+__attribute__((visibility("default"))) void nh_delete_file(const char *path);
+__attribute__((visibility("default"))) void nh_delete_dir(const char *path);
 
 // nh_log logs a message with a prefix based on the mod name, and should be used
 // for all logging. Messages larger than 256 bytes will be silently  truncated.

--- a/NickelHook.h
+++ b/NickelHook.h
@@ -66,7 +66,7 @@ struct nh_dlsym {
 
 // nh_delete_path deletes the provided path if it exists. It performs some checks
 // to detect and avoid deleting critical system files
-__attribute__((visibility("default"))) void nh_delete_path(const char *path);
+__attribute__((visibility("default"))) void nh_delete_path(const char *path, bool is_dir);
 
 // nh_log logs a message with a prefix based on the mod name, and should be used
 // for all logging. Messages larger than 256 bytes will be silently  truncated.

--- a/NickelHook.h
+++ b/NickelHook.h
@@ -67,10 +67,9 @@ struct nh_dlsym {
 
 // nh_delete_* deletes the provided path if it exists. It performs some checks
 // to detect and avoid deleting critical system files. The functions return true
-// if the path was removed, or false otherwise.
-// Note, nh_delete_dir will only delete empty directories. Use nh_delete_file and/or
-// nh_delete_dir to delete any files or directories within before attempting to delete
-// a directory.
+// if the path was removed or does not exist, and false on error. nh_delete_dir will only
+// delete empty directories. Use nh_delete_file and/or nh_delete_dir to delete any
+// files or directories within before attempting to delete a directory.
 __attribute__((visibility("default"))) bool nh_delete_file(const char *path);
 __attribute__((visibility("default"))) bool nh_delete_dir(const char *path);
 

--- a/NickelHook.h
+++ b/NickelHook.h
@@ -67,9 +67,10 @@ struct nh_dlsym {
 
 // nh_delete_* deletes the provided path if it exists. It performs some checks
 // to detect and avoid deleting critical system files. The functions return true
-// if the path was removed or does not exist, and false on error. nh_delete_dir will only
-// delete empty directories. Use nh_delete_file and/or nh_delete_dir to delete any
-// files or directories within before attempting to delete a directory.
+// if the path was removed or does not exist, and false on error. nh_delete_dir
+// will only delete empty directories. Use nh_delete_file and/or nh_delete_dir
+// to delete any files or directories within before attempting to delete a
+// directory.
 __attribute__((visibility("default"))) bool nh_delete_file(const char *path);
 __attribute__((visibility("default"))) bool nh_delete_dir(const char *path);
 

--- a/NickelHook.h
+++ b/NickelHook.h
@@ -36,6 +36,7 @@ struct nh_info {
     const char *desc;            // default: none - human-readable description
     const char *uninstall_flag;  // default: none - path to flag which triggers an uninstall and deletes itself if it exists
     const char *uninstall_xflag; // default: none - path to flag which triggers an uninstall if it is deleted
+    const char **uninstall_files;// default: none - null terminated array of file/directory paths to delete during uninstall
     int        failsafe_delay;   // default: 0    - delay in seconds before disarming failsafe
 
     // TODO: maybe a mechanism to only load the latest version?

--- a/nh.c
+++ b/nh.c
@@ -64,6 +64,10 @@ __attribute__((visibility("hidden"))) void nh_failsafe_destroy(nh_failsafe_t *fs
 // used afterwards.
 __attribute__((visibility("hidden"))) void nh_failsafe_uninstall(nh_failsafe_t *fs);
 
+// nh_delete_path deletes the provided path if it exists. It performs some checks
+// to detect and avoid deleting critical system files
+__attribute__((visibility("hidden"))) void nh_delete_path(const char *path, bool is_dir);
+
 // The following blacklist helps prevent any whoopsies when deleting files or directories during uninstall
 
 // Let's not allow deleting any files in /bin, /sbin, /etc/init.d or u-boot stuff.
@@ -83,7 +87,7 @@ void nh_delete_path(const char *path, bool is_dir) {
         nh_log("(NickelHook) no path supplied");
         return;
     }
-    const char *canonical_path;
+    char *canonical_path;
     // lets not play the guessing game with PATH_MAX
     // note, this is from GNU, so _GNU_SOURCE is required
     if ((canonical_path = canonicalize_file_name(path))) {
@@ -103,6 +107,14 @@ void nh_delete_path(const char *path, bool is_dir) {
     } else {
         nh_log("(NickelHook) unable to get canonical path for %s : %m", path);
     }
+}
+
+void nh_delete_file(const char *path) {
+    nh_delete_path(path, false);
+}
+
+void nh_delete_dir(const char *path) {
+    nh_delete_path(path, true);
 }
 
 // --- init

--- a/nh.c
+++ b/nh.c
@@ -474,7 +474,7 @@ void nh_failsafe_uninstall(nh_failsafe_t *fs) {
 
 // --- File/directory deletion
 
-// The following blacklist helps prevent any whoopsies when deleting files or directories during uninstall
+// The following blacklist helps prevent any whoopsies when deleting files or directories during uninstall.
 
 // Let's not allow deleting any files in /bin, /sbin, /etc/init.d or u-boot stuff.
 static const char *delete_prefix_blacklist[] = {
@@ -498,14 +498,16 @@ bool nh_delete_path(const char *path, bool is_dir) {
         nh_log("(NickelHook) unable to get canonical path for %s : %m", path);
         return false;
     }
-    for (unsigned int i = 0; i < (sizeof(delete_prefix_blacklist) / sizeof(delete_prefix_blacklist[0])); i++) {
+    for (size_t i = 0; i < (sizeof(delete_prefix_blacklist) / sizeof(*delete_prefix_blacklist)); i++) {
         if (!strncmp(delete_prefix_blacklist[i], canonical_path, strlen(delete_prefix_blacklist[i]))) {
             nh_log("(NickelHook) not deleting %s with blacklisted prefix %s", canonical_path, delete_prefix_blacklist[i]);
             return false;
         }
     }
-    nh_log("(NickelHook) ... deleting %s %s", (is_dir ? "directory" : "file") ,canonical_path);
-    int res = is_dir ? rmdir(canonical_path) : unlink(canonical_path);
+    nh_log("(NickelHook) ... deleting %s %s", (is_dir ? "directory" : "file"), canonical_path);
+    int res = is_dir 
+        ? rmdir(canonical_path) 
+        : unlink(canonical_path);
     if (res == -1) {
         nh_log("(NickelHook) failed to delete %s, with error: %m", canonical_path);
         return false;

--- a/nh.c
+++ b/nh.c
@@ -470,9 +470,11 @@ void nh_failsafe_uninstall(nh_failsafe_t *fs) {
 
 // --- File/directory deletion
 
-// The following blacklist helps prevent any whoopsies when deleting files or directories during uninstall.
+// The following blacklist helps prevent any whoopsies when deleting files or
+// directories during uninstall.
 
-// Let's not allow deleting any files in /bin, /sbin, /etc/init.d or u-boot stuff.
+// Let's not allow deleting any files in /bin, /sbin, /etc/init.d or u-boot
+// stuff.
 static const char *delete_prefix_blacklist[] = {
     "/bin",
     "/sbin",
@@ -482,11 +484,11 @@ static const char *delete_prefix_blacklist[] = {
     "/usr/local/Kobo/pickel",
 };
 
-// nh_delete_path deletes the provided path if it exists. It performs some checks
-// to detect and avoid deleting critical system files
-// 
-// This is for the schmuck who forgot to terminate his array of paths
-// and accidentally deleted '/bin/sh' due to an out-of-bounds read.
+// nh_delete_path deletes the provided path if it exists. It performs some
+// checks to detect and avoid deleting critical system files
+//
+// This is for the schmuck who forgot to terminate his array of paths and
+// accidentally deleted '/bin/sh' due to an out-of-bounds read.
 static bool nh_delete_path(const char *path, bool is_dir) {
     if (!path) {
         nh_log("(NickelHook) no path supplied");

--- a/nh.c
+++ b/nh.c
@@ -507,7 +507,7 @@ static bool nh_delete_path(const char *path, bool is_dir) {
     int res = is_dir 
         ? rmdir(fn) 
         : unlink(fn);
-    if (res == -1) {
+    if (res == -1 && errno != ENOENT) {
         nh_log("(NickelHook) failed to delete %s, with error: %m", fn);
         return false;
     }

--- a/nh.c
+++ b/nh.c
@@ -67,9 +67,10 @@ __attribute__((visibility("hidden"))) void nh_failsafe_uninstall(nh_failsafe_t *
 // The following blacklist helps prevent any whoopsies when deleting files or directories during uninstall
 
 // Let's not allow deleting any files in /bin, /sbin, /etc/init.d or u-boot stuff.
-static const char *delete_blacklist[] = {
+static const char *delete_prefix_blacklist[] = {
     "/bin",
     "/sbin",
+    // note, '/etc/u-boot/*/u-boot.recovery' is a critical file for recovery
     "/etc/u-boot",
     "/etc/init.d",
     "/usr/local/Kobo/pickel",
@@ -86,9 +87,9 @@ void nh_delete_path(const char *path, bool is_dir) {
     // lets not play the guessing game with PATH_MAX
     // note, this is from GNU, so _GNU_SOURCE is required
     if ((canonical_path = canonicalize_file_name(path))) {
-        for (unsigned int i = 0; i < (sizeof(delete_blacklist) / sizeof(*delete_blacklist)); i++) {
-            if (!strncmp(delete_blacklist[i], canonical_path, strlen(delete_blacklist[i]))) {
-                nh_log("(NickelHook) not deleting %s with blacklisted prefix %s", canonical_path, delete_blacklist[i]);
+        for (unsigned int i = 0; i < (sizeof(delete_prefix_blacklist) / sizeof(delete_prefix_blacklist[0])); i++) {
+            if (!strncmp(delete_prefix_blacklist[i], canonical_path, strlen(delete_prefix_blacklist[i]))) {
+                nh_log("(NickelHook) not deleting %s with blacklisted prefix %s", canonical_path, delete_prefix_blacklist[i]);
                 free(canonical_path);
                 return;
             }

--- a/nh.c
+++ b/nh.c
@@ -493,23 +493,23 @@ bool nh_delete_path(const char *path, bool is_dir) {
         nh_log("(NickelHook) no path supplied");
         return false;
     }
-    char canonical_path[PATH_MAX] = {0};
-    if (!realpath(path, canonical_path)) {
+    char fn[PATH_MAX] = {0};
+    if (!realpath(path, fn)) {
         nh_log("(NickelHook) unable to get canonical path for %s : %m", path);
         return false;
     }
     for (size_t i = 0; i < (sizeof(delete_prefix_blacklist) / sizeof(*delete_prefix_blacklist)); i++) {
-        if (!strncmp(delete_prefix_blacklist[i], canonical_path, strlen(delete_prefix_blacklist[i]))) {
-            nh_log("(NickelHook) not deleting %s with blacklisted prefix %s", canonical_path, delete_prefix_blacklist[i]);
+        if (!strncmp(delete_prefix_blacklist[i], fn, strlen(delete_prefix_blacklist[i]))) {
+            nh_log("(NickelHook) not deleting %s with blacklisted prefix %s", fn, delete_prefix_blacklist[i]);
             return false;
         }
     }
-    nh_log("(NickelHook) ... deleting %s %s", (is_dir ? "directory" : "file"), canonical_path);
+    nh_log("(NickelHook) ... deleting %s %s", (is_dir ? "directory" : "file"), fn);
     int res = is_dir 
-        ? rmdir(canonical_path) 
-        : unlink(canonical_path);
+        ? rmdir(fn) 
+        : unlink(fn);
     if (res == -1) {
-        nh_log("(NickelHook) failed to delete %s, with error: %m", canonical_path);
+        nh_log("(NickelHook) failed to delete %s, with error: %m", fn);
         return false;
     }
     return true;

--- a/nh.c
+++ b/nh.c
@@ -162,8 +162,8 @@ void nh_init() {
             nh_log("(NickelHook) ... info: flag found, uninstalling");
             unlink(nh->info->uninstall_flag);
             nh_failsafe_uninstall(fs);
-            if (nh->uninstall) {
-                nh->uninstall();
+            if (nh->uninstall && !nh->uninstall()) {
+                nh_dump_log();
             }
             goto nh_init_return_no_fs;
         }
@@ -174,8 +174,8 @@ void nh_init() {
         if (access(nh->info->uninstall_xflag, F_OK) && errno == ENOENT) {
             nh_log("(NickelHook) ... info: flag removed, uninstalling");
             nh_failsafe_uninstall(fs);
-            if (nh->uninstall) {
-                nh->uninstall();
+            if (nh->uninstall && !nh->uninstall()) {
+                nh_dump_log();
             }
             goto nh_init_return_no_fs;
         }

--- a/nh.c
+++ b/nh.c
@@ -87,14 +87,11 @@ void nh_delete_path(const char *path, bool is_dir) {
         nh_log("(NickelHook) no path supplied");
         return;
     }
-    char *canonical_path;
-    // lets not play the guessing game with PATH_MAX
-    // note, this is from GNU, so _GNU_SOURCE is required
-    if ((canonical_path = canonicalize_file_name(path))) {
+    char canonical_path[PATH_MAX] = {0};
+    if (realpath(path, canonical_path)) {
         for (unsigned int i = 0; i < (sizeof(delete_prefix_blacklist) / sizeof(delete_prefix_blacklist[0])); i++) {
             if (!strncmp(delete_prefix_blacklist[i], canonical_path, strlen(delete_prefix_blacklist[i]))) {
                 nh_log("(NickelHook) not deleting %s with blacklisted prefix %s", canonical_path, delete_prefix_blacklist[i]);
-                free(canonical_path);
                 return;
             }
         }
@@ -103,7 +100,6 @@ void nh_delete_path(const char *path, bool is_dir) {
         if (res == -1) {
             nh_log("(NickelHook) failed to delete %s, with error: %m", canonical_path);
         }
-        free(canonical_path);
     } else {
         nh_log("(NickelHook) unable to get canonical path for %s : %m", path);
     }

--- a/nh.c
+++ b/nh.c
@@ -64,10 +64,6 @@ __attribute__((visibility("hidden"))) void nh_failsafe_destroy(nh_failsafe_t *fs
 // used afterwards.
 __attribute__((visibility("hidden"))) void nh_failsafe_uninstall(nh_failsafe_t *fs);
 
-// nh_delete_path deletes the provided path if it exists. It performs some checks
-// to detect and avoid deleting critical system files
-__attribute__((visibility("hidden"))) bool nh_delete_path(const char *path, bool is_dir);
-
 // --- init
 
 void nh_init() {
@@ -486,9 +482,12 @@ static const char *delete_prefix_blacklist[] = {
     "/usr/local/Kobo/pickel",
 };
 
+// nh_delete_path deletes the provided path if it exists. It performs some checks
+// to detect and avoid deleting critical system files
+// 
 // This is for the schmuck who forgot to terminate his array of paths
 // and accidentally deleted '/bin/sh' due to an out-of-bounds read.
-bool nh_delete_path(const char *path, bool is_dir) {
+static bool nh_delete_path(const char *path, bool is_dir) {
     if (!path) {
         nh_log("(NickelHook) no path supplied");
         return false;


### PR DESCRIPTION
This is a redo and extension of #2 

I'm opening this as a draft until we get all the finer details nailed down.

This PR adds two new public functions to the API. They are `void nh_delete_file(const char *path)`, and ``void nh_delete_dir(const char *path)`. Internally, these functions call `void nh_delete_path(const char *path, bool is_dir)` which is responsible for checking the path against a list of predetermined blacklisted path prefixes. The functions will not delete any file or dir that includes a blacklisted prefix.

Additionally, mod developers can provide an uninstall function pointer in the `nh` struct, to allow the mod to perform any necessary cleanup during mod uninstallation.